### PR TITLE
Resolve null pointer dereference when reattaching a volume

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -40,11 +40,7 @@ func waitForLinodeVolumeDetachment(linodeAPI linodego.Client, volumeID int) erro
 			return false
 		}
 
-		if v.LinodeID == nil {
-			return true // detached
-		}
-
-		return false
+		return v.LinodeID == nil
 	})
 }
 


### PR DESCRIPTION
This change resolves a null pointer deference that occurs when detaching a volume from another Linode during a volume mount. Additionally, some confusing logic has been cleaned up and a broken Docker API call has been resolved.