### PR TITLE
Add force-attach option to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ linode-token=<linode token> linode-label=<linode label>
 | --- | --- |
 | linode-token | **Required** The Linode APIv4 [Personal Access Token](https://cloud.linode.com/profile/tokens)
 | linode-label | **Required** The Linode Label set at creation
-| mount-root | Sets the root directory for volume mounts (default /mnt) |
+| force-attach | If true, volumes will be forcibly attached to the current Linode if already attached to another Linode. (defaults to false) WARNING: Forcibly reattaching volumes can result in data loss if a volume is not properly unmounted.
+| mount-root | Sets the root directory for volume mounts (defaults to /mnt) |
 | log-level | Sets log level to debug,info,warn,error (defaults to info) |
 | socket-user | Sets the user to create the docker socket with (defaults to root) |
 

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   "env": [
     { "name": "linode-token",  "settable": [ "value" ], "value": "" },
     { "name": "linode-label",   "settable": [ "value" ], "value": "" },
+    { "name": "force-attach",  "settable": [ "value" ], "value": "false" },
     { "name": "socket-user",  "settable": [ "value" ], "value": "root" },
     { "name": "mount-root",  "settable": [ "value" ], "value": "/mnt" },
     { "name": "log-level",  "settable": [ "value" ], "value": "info" }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,8 @@ import (
 var VERSION string
 
 var (
-	mountRoot   = cfgString("mount-root", "/mnt", "the location to mount volumes")
+	forceAttach = cfgBool("force-attach", false, "If true, volumes will be forcibly attached to the current Linode if already attached to another Linode.")
+	mountRoot   = cfgString("mount-root", "/mnt", "The location to mount volumes to.")
 	socketUser  = cfgString("socket-user", "root", "Sets the user to create the socket with.")
 	logLevel    = cfgString("log-level", "info", "Sets log level: debug,info,warn,error")
 	linodeToken = cfgString("linode-token", "", "Required Personal Access Token generated in Linode Console.")
@@ -63,6 +64,16 @@ func cfgString(name string, def string, desc string) *string {
 		newDef = val
 	}
 	return flag.String(name, newDef, desc)
+}
+
+func cfgBool(name string, def bool, desc string) bool {
+	val, found := getEnv(name)
+	if !found {
+		return false
+	}
+
+	valNormalized := strings.ToLower(val)
+	return valNormalized == "true" || valNormalized == "1"
 }
 
 func getEnv(name string) (string, bool) {


### PR DESCRIPTION
This change adds a `force-attach` option which will forcibly detach a volume from a remote Linode during a `driver.Mount(...)` call. 

This is necessary becase the plugin can currently only infer whether a volume is in use by whether or not it is currently attached to a Linode. In certain edge cases, an error in `driver.Mount(...)` or `driver.Unmount(...)` can result in a dangling volume remaining mounted to a Linode despite not being mounted on a container. Resolving this issue requires manual user intervention to prevent data loss, or `force-attach` to be set to true.

Users can enable `force-attach` by running the following command:
```shell
docker plugin set linode/docker-volume-linode force-attach=true
```

See #27 