### PR TITLE
Do not attach volume to current Linode on creation

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -190,9 +190,9 @@ func (driver *linodeVolumeDriver) Create(req *volume.CreateRequest) error {
 	}
 
 	createOpts := linodego.VolumeCreateOptions{
-		Label:    req.Name,
-		LinodeID: driver.instanceID,
-		Size:     size,
+		Label:  req.Name,
+		Region: driver.region,
+		Size:   size,
 	}
 
 	if fsOpt, ok := req.Options["filesystem"]; ok {


### PR DESCRIPTION
Attaching a volume after creation on the current Linode can lead to attachment issues if `force-attach=false`. When a volume is mounted, it will automatically be attached to the correct Linode.