### PR TITLE
test: replace legacy region in deploy.yml

### DIFF
--- a/quick-test/deploy.yml
+++ b/quick-test/deploy.yml
@@ -5,7 +5,7 @@
     ssh_pubkey_path: ~/.ssh/id_rsa.pub
     label: docker-volume-test
     type: g6-standard-2
-    region: us-southeast
+    region: us-ord
     temp_token_name: docker-volume-linode-dev
     token_duration_seconds: 3600
   tasks:


### PR DESCRIPTION
## 📝 Description

Regions have been updated:
Legacy Compute sites are in Atlanta, Dallas, Frankfurt, Fremont, London, Mumbai, Newark, Singapore, Sydney, Tokyo, and Toronto

New Core Compute sites are in Amsterdam, Chennai, Chicago, Jakarta, Los Angeles, Madrid (coming soon!), Miami, Milan, Osaka, Paris, São Paulo, Seattle, Stockholm, and Washington, DC (and the list will continue to grow).

All integration test runs provision infrastructure only in New Core Compute sites (not Legacy Compute sites). For this repository, replacing all legacy regions with Chicago and Miami region

## ✔️ How to Test

 make QUICKTEST_SSH_PUBKEY="~/.ssh/mykey.pub" quick-test

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**