### PR TITLE
test: add cloud-init hardening for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ $(PLUGIN_DIR): *.go Dockerfile
 	docker rm -vf tmp
 
 # Provision a test environment for docker-volume-linode using Ansible.
+.PHONY: quick-test
 quick-test:
 	ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook -v --extra-vars "ssh_pubkey_path=${QUICKTEST_SSH_PUBKEY} skip_tests=${QUICKTEST_SKIP_TESTS}" quick-test/deploy.yml
 

--- a/quick-test/deploy.yml
+++ b/quick-test/deploy.yml
@@ -32,8 +32,8 @@
         region: "{{ region }}"
         image: linode/alpine3.18
         booted: true
-        authorized_keys:
-          - "{{ lookup('file', ssh_pubkey_path) }}"
+        metadata:
+          user_data: '{{ lookup("template", playbook_dir ~ "/harden.yaml.j2") }}'
         state: present
       register: create_inst
 

--- a/quick-test/deploy.yml
+++ b/quick-test/deploy.yml
@@ -14,6 +14,9 @@
         label: "{{ temp_token_name }}"
         state: absent
 
+    - set_fact:
+        ssh_pubkey: '{{ lookup("file", ssh_pubkey_path) }}'
+
     - name: Create a temporary token for the plugin to consume
       linode.cloud.token:
         label: "{{ temp_token_name }}"

--- a/quick-test/harden.yaml.j2
+++ b/quick-test/harden.yaml.j2
@@ -1,0 +1,36 @@
+#cloud-config
+hostname: dx-dev-vm
+
+package_update: true
+package_upgrade: true
+packages:
+  - fail2ban
+
+ssh_pwauth: false
+disable_root: true
+
+users:
+  - default
+  - name: linodedx
+    gecos: The primary account for development on this VM.
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+    ssh_authorized_keys:
+      - '{{ ssh_pubkey }}'
+
+write_files:
+  # Root login over SSH isn't fully disabled by disable_root
+  - path: /etc/ssh/sshd_config.d/51-disable-root.conf
+    permissions: "0600"
+    content: |
+      PermitRootLogin no
+
+runcmd:
+  - service ssh restart
+  - service fail2ban start --enable
+
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 80,443,21,22/tcp
+  - ufw enable


### PR DESCRIPTION
## 📝 Description

The [quick-test playbook](https://github.com/linode/docker-volume-linode/blob/main/quick-test/deploy.yml) uses a cloud-init hardening configuration similar to https://gist.github.com/lgarber-akamai/39249a70b523013396ce6d513c1310c9

## ✔️ How to Test

make quick-test

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**