### PR TITLE
Bump go.mod and Dockerfile Go version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 ENV GO111MODULE=on
 ARG VERSION=0
 COPY . /docker-volume-linode

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/linode/docker-volume-linode
 
-go 1.22
+go 1.23
 
-toolchain go1.22.5
+toolchain go1.23.7
 
 require (
 	github.com/docker/go-plugins-helpers v0.0.0-20211224144127-6eecb7beb651


### PR DESCRIPTION
## 📝 Description

This pull request bumps the Go version to 1.23 in the `go.mod` and `Dockerfile` files. This is necessary to prevent CI failures in Dependabot PRs, which occur because Dependabot tries to pin the toolchain version to `1.23.7`.

## ✔️ How to Test

**NOTE: These test instructions assume you have pulled down this PR locally and have Docker installed on your machine. **

1. Run `make build`
2. Ensure the project builds successfully using Docker.
