### PR TITLE
Configure API token using LinodeClient{}.SetToken(...) rather than transport; allow configuring LINODE_CA

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,46 @@
+version: "2"
+
+run:
+  tests: false
+
+linters:
+  settings:
+    dupl:
+      threshold: 100
+
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/linode/linodego
+
+    govet:
+      disable:
+        - shadow
+
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+
+    staticcheck:
+      checks: ["all", "-ST1005"]
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/driver.go
+++ b/driver.go
@@ -5,15 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/oauth2"
 
 	"github.com/docker/go-plugins-helpers/volume"
 	metadata "github.com/linode/go-metadata"
@@ -72,16 +69,13 @@ func (driver *linodeVolumeDriver) linodeAPI() (*linodego.Client, error) {
 }
 
 func setupLinodeAPI(token string) *linodego.Client {
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	oauth2Client := &http.Client{
-		Transport: &oauth2.Transport{
-			Source: tokenSource,
-		},
-	}
+	api := linodego.NewClient(nil)
 
-	api := linodego.NewClient(oauth2Client)
 	ua := fmt.Sprintf("docker-volume-linode/%s linodego/%s", VERSION, linodego.Version)
 	api.SetUserAgent(ua)
+
+	api.SetToken(token)
+
 	return &api
 }
 

--- a/fs_utils_linux.go
+++ b/fs_utils_linux.go
@@ -46,7 +46,7 @@ func GetFSType(device string) string {
 		for _, v := range strings.Split(string(out), " ") {
 			if strings.Contains(v, "TYPE=") {
 				fsType = strings.Split(v, "=")[1]
-				fsType = strings.Replace(fsType, "\"", "", -1)
+				fsType = strings.ReplaceAll(fsType, "\"", "")
 			}
 		}
 	}

--- a/integration-test/test.yaml
+++ b/integration-test/test.yaml
@@ -35,7 +35,7 @@
         label: "{{ label }}"
         type: "{{ type }}"
         region: "{{ region }}"
-        image: linode/ubuntu23.10
+        image: linode/ubuntu24.04
         booted: true
         metadata:
           user_data: '{{ lookup("template", playbook_dir ~ "/harden.yaml.j2") }}'

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func getEnv(name string) (string, bool) {
 	}
 
 	name = strings.ToUpper(name)
-	name = strings.Replace(name, "-", "_", -1)
+	name = strings.ReplaceAll(name, "-", "_")
 
 	if val, found := os.LookupEnv(name); found {
 		return val, true


### PR DESCRIPTION
## 📝 Description

This pull request updates the linodego.Client creation logic to set the user-configured API token using the `LinodeClient{}.SetToken(...)` function rather than using a custom oauth2 transport. This allows the `LINODE_CA` environment variable to be specified without any additional logic to set the trusted root CA, which is necessary because linodego can only modify an HTTP client's trusted CAs if the user-provided client's RoundTripper is a *http.Transport.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally, have Ansible installed, have an SSH public key exported under `~/.ssh/id_rsa.pub`, and have a valid Linode API token exported under the `LINODE_TOKEN` environment variable.

### Integration Testing

1. Run the following command to kick off the integration tests:

```shell
make int-test
```

### Manual Testing

TODO